### PR TITLE
Clarify format of numbers in type strings & add more docs to types

### DIFF
--- a/ARCs/arc-0004.md
+++ b/ARCs/arc-0004.md
@@ -147,7 +147,12 @@ interface Method {
     desc?: string
   }>,
   /** Information about the method's return value */
-  returns: { type: string, desc?: string }
+  returns: {
+    /** The type of the return value, or "void" to indicate no return value. */
+    type: string,
+    /** Optional, user-friendly description for the return value */
+    desc?: string
+  }
 }
 ```
 
@@ -320,9 +325,13 @@ interface Contract {
   networks?: {
     /**
      * The key is the base64 genesis hash of the network, and the value contains
-     * the app ID of the deployed contract in that network
+     * information about the deployed contract in the network indicated by the
+     * key
      */
-    [network: string]: { appID: number }
+    [network: string]: {
+      /** The app ID of the deployed contract in this network */
+      appID: number
+    }
   }
   /** All of the methods that the contract implements */
   methods: Method[]
@@ -495,16 +504,24 @@ properties:
 
 The following types are supported in the Algorand ABI.
 
-* `uint<N>`: An `N`-bit unsigned integer, where `8 <= N <= 512` and `N % 8 = 0`.
+* `uint<N>`: An `N`-bit unsigned integer, where `8 <= N <= 512` and `N % 8 = 0`. When this type is
+used as part of a method signature, `N` must be written as a base 10 number without any leading zeros.
 * `byte`: An alias for `uint8`.
-* `bool`: A boolean value that is restricted to either 0 or 1. When encoded, up to 8 consecutive `bool` values will be packed into a single byte.
-* `ufixed<N>x<M>`: An `N`-bit unsigned fixed-point decimal number with precision `M`, where `8 <= N <= 512`, `N % 8 = 0`, and `0 < M <= 160`, which denotes a value `v` as `v / (10^M)`.
+* `bool`: A boolean value that is restricted to either 0 or 1. When encoded, up to 8 consecutive
+`bool` values will be packed into a single byte.
+* `ufixed<N>x<M>`: An `N`-bit unsigned fixed-point decimal number with precision `M`, where
+`8 <= N <= 512`, `N % 8 = 0`, and `0 < M <= 160`, which denotes a value `v` as `v / (10^M)`. When
+this type is used as part of a method signature, `N` and `M` must be written as base 10 numbers
+without any leading zeros.
 * `<type>[<N>]`: A fixed-length array of length `N`, where `N >= 0`. `type` can be any other type.
+When this type is used as part of a method signature, `N` must be written as a base 10 number without
+any leading zeros, _unless_ `N` is zero, in which case only a single 0 character should be used.
 * `address`: Used to represent a 32-byte Algorand address. This is equivalent to `byte[32]`.
 * `<type>[]`: A variable-length array. `type` can be any other type.
 * `string`: A variable-length byte array (`byte[]`) assumed to contain UTF-8 encoded content.
-* `(T1,T2,...,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 0`.
-* reference types `account`, `asset`, `application`: only for arguments, in which case they are an alias for `uint8`. See section "Reference Types" below.
+* `(T1,T2,…,TN)`: A tuple of the types `T1`, `T2`, …, `TN`, `N >= 0`.
+* reference types `account`, `asset`, `application`: only for arguments, in which case they are an
+alias for `uint8`. See section "Reference Types" below.
 
 Additional special use types are defined in [Reference Types](#reference-types)
 and [Transaction Types](#transaction-types).


### PR DESCRIPTION
This PR adds two things:
* More descriptions for JSON fields that were missed before
* Clarifies how numbers in types should be encoded. This is meant to state that types with leading zeros like `uint064` and `bool[008]` are invalid, since for method selector hashes to be consistent, there must only be one way to represent each type.